### PR TITLE
feat: fire multiple show/hide events

### DIFF
--- a/custom-elements/auto-complete-element/CHANGELOG.md
+++ b/custom-elements/auto-complete-element/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Allow clicking inside the list
+- Fire events such as `auto-complete:show`, `auto-complete:shown`, `auto-complete:hide`, and `auto-complete:hidden`
 
 ## [0.1.2] - 2022-06-18
 

--- a/custom-elements/auto-complete-element/README.md
+++ b/custom-elements/auto-complete-element/README.md
@@ -124,7 +124,11 @@ li[role="option"][aria-selected="true"] > span {
 ```
 
 ### Events
-`auto-complete:selected` is fired after an option is selected. You can find which option was selected
+- `auto-complete:show` is fired immediately after removing the `hidden` attribute.
+- `auto-complete:shown` is fired after attaching the combobox functionality.
+- `auto-complete:hide` is fired immediately after adding the `hidden` attribute.
+- `auto-complete:hidden` is fired after removing the combobox functionality.
+- `auto-complete:selected` is fired after an option is selected. You can find which option was selected
 by:
 
 ```js
@@ -136,7 +140,7 @@ autocomplete.addEventListener('auto-complete:selected', (event) => {
 });
 ```
 
-`auto-complete:reset` is fired after `data-autocomplete-reset` has been clicked.
+- `auto-complete:reset` is fired after `data-autocomplete-reset` has been clicked.
 
 ## License
 Distributed under the MIT license.

--- a/custom-elements/auto-complete-element/spec/index.spec.ts
+++ b/custom-elements/auto-complete-element/spec/index.spec.ts
@@ -73,6 +73,52 @@ describe('AutoCompleteElement', () => {
       expect(list).not.to.have.attribute('hidden');
       expect(document.activeElement).to.equal(input);
     });
+
+    it('dispatches show and shown event in order', () => {
+      let count = 0;
+      document.addEventListener(
+        'auto-complete:show',
+        () => {
+          count += 1;
+          expect(count).to.equal(1);
+        },
+        { once: true }
+      );
+
+      document.addEventListener(
+        'auto-complete:shown',
+        () => {
+          count += 1;
+          expect(count).to.equal(2);
+        },
+        { once: true }
+      );
+
+      input.focus();
+    });
+
+    it('dispatches hide and hidden event in order', () => {
+      let count = 0;
+      document.addEventListener(
+        'auto-complete:hide',
+        () => {
+          count += 1;
+          expect(count).to.equal(1);
+        },
+        { once: true }
+      );
+
+      document.addEventListener(
+        'auto-complete:hidden',
+        () => {
+          count += 1;
+          expect(count).to.equal(2);
+        },
+        { once: true }
+      );
+
+      input.focus();
+    });
   });
 
   describe('with no previous aria-selected option', () => {

--- a/custom-elements/auto-complete-element/src/autocomplete.ts
+++ b/custom-elements/auto-complete-element/src/autocomplete.ts
@@ -68,11 +68,15 @@ export default class Autocomplete {
 
   onListToggle() {
     if (this.list.hidden) {
+      dispatchEvent(this.element, 'hide');
       this.combobox.stop();
       this.list.removeAttribute(DATA_EMPTY_ATTR);
+      dispatchEvent(this.element, 'hidden');
       syncSelection(this);
     } else {
+      dispatchEvent(this.element, 'show');
       this.combobox.start();
+      dispatchEvent(this.element, 'shown');
     }
   }
 
@@ -144,12 +148,7 @@ export default class Autocomplete {
       this.list.hidden = true;
     }
 
-    this.list.dispatchEvent(
-      new CustomEvent('auto-complete:selected', {
-        detail: { relatedTarget: option },
-        bubbles: true,
-      })
-    );
+    dispatchEvent(this.element, 'selected', { detail: { relatedTarget: option } });
   }
 
   onBlur(event: FocusEvent) {
@@ -182,7 +181,7 @@ export default class Autocomplete {
     }
 
     // Should fire after closing the list
-    this.list.dispatchEvent(new CustomEvent('auto-complete:reset', { bubbles: true }));
+    dispatchEvent(this.element, 'reset');
   }
 
   openAndInitializeList() {
@@ -235,4 +234,8 @@ function syncSelection(autocomplete: Autocomplete) {
 
 function selected(option: HTMLElement) {
   return option.getAttribute('aria-selected') === 'true';
+}
+
+function dispatchEvent(element: HTMLElement, name: string, options: CustomEventInit = {}) {
+  element.dispatchEvent(new CustomEvent(`auto-complete:${name}`, { bubbles: true, ...options }));
 }


### PR DESCRIPTION
Fire these events: `auto-complete:show`, `auto-complete:shown`, `auto-complete:hide`, and `auto-complete:hidden`