### PR TITLE
fix: auto-complete does not close when clicking outside

### DIFF
--- a/custom-elements/auto-complete-element/CHANGELOG.md
+++ b/custom-elements/auto-complete-element/CHANGELOG.md
@@ -5,22 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Auto complete does not close when clicking outside on Firefox - [#19](https://github.com/Ambiki/ambiki-packages/pull/19)
+
 ## [0.2.0] - 2022-07-18
+
 ### Added
+
 - Allow clicking inside the list
 - Fire events such as `auto-complete:show`, `auto-complete:shown`, `auto-complete:hide`, and `auto-complete:hidden`
 
 ## [0.1.2] - 2022-06-18
 
 ### Fixed
+
 - Auto complete queries for `<input type="hidden">` elements
 
 ## [0.1.1] - 2022-06-18
 
 ### Changed
+
 - Changed bundle format from `CommonJS` to `ECMAScript module`
 
 ## [0.1.0] - 2022-06-15
 
 ### Added
+
 - Everything!

--- a/custom-elements/auto-complete-element/spec/index.spec.ts
+++ b/custom-elements/auto-complete-element/spec/index.spec.ts
@@ -274,10 +274,11 @@ describe('AutoCompleteElement', () => {
       expect(relatedTarget).to.equal(options[1]);
     });
 
-    it('retains focus on the input field', () => {
+    it('retains focus on the input field', async () => {
       input.focus();
       options[1].focus();
       options[1].click();
+      await nextTick();
 
       expect(document.activeElement).to.equal(input);
     });

--- a/custom-elements/auto-complete-element/src/autocomplete.ts
+++ b/custom-elements/auto-complete-element/src/autocomplete.ts
@@ -151,7 +151,7 @@ export default class Autocomplete {
     dispatchEvent(this.element, 'selected', { detail: { relatedTarget: option } });
   }
 
-  onBlur(event: FocusEvent) {
+  async onBlur(event: FocusEvent) {
     const { relatedTarget } = event;
     if (!(relatedTarget instanceof HTMLElement)) {
       this.list.hidden = true;
@@ -160,6 +160,7 @@ export default class Autocomplete {
 
     const list = relatedTarget.closest<HTMLElement>('[role="listbox"]');
     if (list) {
+      await nextTick(); // Wait for nextTick before focusing (Firefox edge case)
       this.input.focus(); // Always keep focus on the input field when interacting with the list
     } else {
       this.list.hidden = true; // Hide the list for other elements that triggered the blur


### PR DESCRIPTION
## Description
The issue existed on Firefox. The fix was to wait for the `nextTick` before focusing on the `input` field.

## Video
https://user-images.githubusercontent.com/50948617/201291813-a2507f2b-a1f2-4cf2-88d3-8efe84cab3aa.mp4

fixes #18