### PR TITLE
bump combobox@1.1.0

### DIFF
--- a/packages/combobox/CHANGELOG.md
+++ b/packages/combobox/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Ureleased]
+## [1.1.0] - 2022-11-24
 
 ### Fixed
 

--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ambiki/combobox",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Extend your autocomplete and command palette using the Combobox, which provides robust keyboard navigation and accessibility out of the box.",
   "homepage": "https://github.com/Ambiki/ambiki-packages/tree/main/packages/combobox",
   "bugs": "https://github.com/Ambiki/ambiki-packages/issues?q=is%3Aopen+is%3Aissue+label%3Acombobox",


### PR DESCRIPTION
### Fixed

- `setActive` function cannot find the option when `option` is a `node`

### Changed

- `setInitialAttributesOnOptions` API takes an array of selected option ids (`string[]`)
- All selected options are unselected when combobox is stopped
