### PR TITLE
fix: option cannot be selected when SVG triggers a click event

### DIFF
--- a/packages/combobox/CHANGELOG.md
+++ b/packages/combobox/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Option cannot be selected/deselected if SVGElement present inside the option is clicked.
+
 ## [2.0.0] - 2023-02-28
 
 ### Changed

--- a/packages/combobox/spec/index.spec.ts
+++ b/packages/combobox/spec/index.spec.ts
@@ -1,5 +1,5 @@
 import { expect, fixture, html } from '@open-wc/testing';
-import { find, findAll, triggerKeyEvent, triggerMouseover } from '@ambiki/test-utils';
+import { find, findAll, triggerEvent, triggerKeyEvent, triggerMouseover } from '@ambiki/test-utils';
 import * as sinon from 'sinon';
 import Combobox from '../src';
 
@@ -156,7 +156,7 @@ describe('Combobox', () => {
   });
 
   it('selects the option on mouse click', async () => {
-    const { container, options, combobox } = await setupFixture({ options: [{ id: 1 }] });
+    const { container, options, combobox } = await setupFixture({ options: [{ id: 1 }, { id: 2 }] });
     const option = options[0];
     combobox.start();
 
@@ -168,6 +168,15 @@ describe('Combobox', () => {
     option.click();
     expect(option).to.have.attribute('aria-selected', 'true');
     expect(commitHandler.calledOnce).to.be.true;
+
+    // Check if elements inside `li` can trigger click
+    const secondOption = options[1];
+    const innerElement = secondOption.querySelector<HTMLElement>('[data-test-id="option-inner"]');
+
+    await triggerEvent(innerElement, 'click');
+    expect(secondOption).to.have.attribute('aria-selected', 'true');
+    expect(commitHandler.called).to.be.true;
+    expect(options[0]).not.to.have.attribute('aria-selected', 'true');
   });
 
   it('does not select a disabled option', async () => {
@@ -360,6 +369,7 @@ async function setupFixture({ options, multiple = false }: SetupFixtureProps) {
               ?disabled="${option.disabled}"
               ?hidden="${option.hidden}"
             >
+              <svg data-test-id="option-inner"></svg>
               ${option.text || 'Option'}
             </li>`
         )}

--- a/packages/combobox/src/index.ts
+++ b/packages/combobox/src/index.ts
@@ -255,11 +255,11 @@ export default class Combobox {
   }
 }
 
-function getClosestOptionFrom(target: HTMLElement | null) {
-  if (!(target instanceof HTMLElement)) return false;
+function getClosestOptionFrom(target: Element | null) {
+  if (!target) return false;
 
   const option = target.closest<HTMLElement>('[role="option"]');
-  if (!(option instanceof HTMLElement)) return false;
+  if (!option) return false;
 
   return option;
 }


### PR DESCRIPTION
We were checking if the target is an instance of `HTMLElement` and proceeding if it is. This will neglect elements such as SVGElement and others as they are not an instance of HTMLElement.

We simply need to check if the `target` exists. If it does, then proceed, else return `false`.

fixes #41 