### PR TITLE
feat: disabled `auto-complete`

### DIFF
--- a/custom-elements/auto-complete-element/CHANGELOG.md
+++ b/custom-elements/auto-complete-element/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support `name` attribute. If present, proper `input[type="hidden"][name="some_name"]` will be appended inside the
   `auto-complete` element with `value` being the selected option's `value` attribute.
 - Reset `auto-complete` when parent `form` element fires a `reset` event.
+- Support `disabled` attribute. If present,
+  - disables the input field
+  - disables the clear button if it exists
+
+  The main idea here is to avoid user interactions. Functions such as `setValue` and `removeValue` will still work as
+  expected.
 
 ## [2.0.1] - 2023-03-02
 

--- a/custom-elements/auto-complete-element/spec/index.spec.ts
+++ b/custom-elements/auto-complete-element/spec/index.spec.ts
@@ -6,13 +6,17 @@ import '../src';
 
 describe('AutoCompleteElement', () => {
   it('adds attributes after initializing', async () => {
-    const { input, list, clearBtn } = await setupFixture({ options: [{ id: 1 }], clearable: true });
+    const { container, input, list, clearBtn } = await setupFixture({ options: [{ id: 1 }], clearable: true });
 
+    expect(container.disabled).to.be.false;
     expect(input).to.have.attribute('spellcheck', 'false');
     expect(input).to.have.attribute('autocomplete', 'off');
+    expect(input.disabled).to.be.false;
     expect(list).to.have.attribute('tabindex', '-1');
     expect(list).to.have.attribute('aria-orientation', 'vertical');
     expect(clearBtn).to.have.attribute('aria-label');
+    expect(clearBtn).not.to.have.attribute('tabindex');
+    expect(clearBtn.disabled).to.be.false;
   });
 
   it('adds attributes after opening the list', async () => {
@@ -185,6 +189,73 @@ describe('AutoCompleteElement', () => {
     await waitUntil(() => options[1].hidden); // search is debounced
     expect(options[1].hidden).to.be.true;
     expect(options[0].hidden).to.be.false;
+  });
+
+  describe('disabled', () => {
+    it('list cannot be opened', async () => {
+      const { container, input, list } = await setupFixture({ options: [{ id: 1 }, { id: 2 }], disabled: true });
+
+      expect(container.disabled).to.be.true;
+      expect(input.disabled).to.be.true;
+
+      await openList(input);
+      expect(list.hidden).to.be.true;
+
+      // Setter shouldn't work either
+      container.open = true;
+      expect(list.hidden).to.be.true;
+    });
+
+    it('clear button is disabled', async () => {
+      const { clearBtn } = await setupFixture({
+        options: [{ id: 1, value: 'foo' }, { id: 2 }],
+        value: 'foo',
+        disabled: true,
+        clearable: true,
+      });
+
+      expect(clearBtn).to.have.attribute('tabindex', '-1');
+      expect(clearBtn.disabled).to.be.true;
+    });
+
+    it('can be disabled using the setter function', async () => {
+      const { container, input, clearBtn } = await setupFixture({
+        options: [{ id: 1 }, { id: 2 }],
+        clearable: true,
+      });
+
+      expect(container.disabled).to.be.false;
+      expect(input.disabled).to.be.false;
+      expect(clearBtn.disabled).to.be.false;
+      expect(clearBtn).not.to.have.attribute('tabindex');
+
+      container.disabled = true;
+
+      expect(container.disabled).to.be.true;
+      expect(input.disabled).to.be.true;
+      expect(clearBtn.disabled).to.be.true;
+      expect(clearBtn).to.have.attribute('tabindex', '-1');
+    });
+
+    it('can be enabled using the setter function', async () => {
+      const { container, input, clearBtn } = await setupFixture({
+        options: [{ id: 1 }, { id: 2 }],
+        clearable: true,
+        disabled: true,
+      });
+
+      expect(container.disabled).to.be.true;
+      expect(input.disabled).to.be.true;
+      expect(clearBtn.disabled).to.be.true;
+      expect(clearBtn).to.have.attribute('tabindex', '-1');
+
+      container.disabled = false;
+
+      expect(container.disabled).to.be.false;
+      expect(input.disabled).to.be.false;
+      expect(clearBtn.disabled).to.be.false;
+      expect(clearBtn).not.to.have.attribute('tabindex');
+    });
   });
 
   describe('#deactivate', () => {

--- a/custom-elements/auto-complete-element/spec/utils.ts
+++ b/custom-elements/auto-complete-element/spec/utils.ts
@@ -35,6 +35,7 @@ export type SetupFixtureProps = {
   multiple?: boolean;
   clearable?: boolean;
   form?: boolean;
+  disabled?: boolean;
 };
 
 export async function setupFixture({
@@ -45,16 +46,18 @@ export async function setupFixture({
   multiple = false,
   clearable = false,
   form = false,
+  disabled = false,
 }: SetupFixtureProps) {
   const _value = Array.isArray(value) ? JSON.stringify(value) : value;
 
   const autoComplete = html`
     <auto-complete
       for="list"
-      ?multiple="${multiple}"
-      name="${typeof name === 'undefined' ? undefined : name}"
-      .value="${typeof _value === 'undefined' ? undefined : _value}"
-      data-label="${typeof label === 'undefined' ? undefined : label}"
+      ?multiple=${multiple}
+      name=${typeof name === 'undefined' ? undefined : name}
+      .value=${typeof _value === 'undefined' ? undefined : _value}
+      data-label=${typeof label === 'undefined' ? undefined : label}
+      ?disabled=${disabled}
     >
       >
       <input type="text" />
@@ -90,7 +93,7 @@ export async function setupFixture({
     input: find<HTMLInputElement>('input'),
     list: find('ul'),
     options: findAll('li[role="option"]'),
-    clearBtn: find('button[data-clear]'),
-    resetBtn: find('button[type="reset"]'),
+    clearBtn: find<HTMLButtonElement>('button[data-clear]'),
+    resetBtn: find<HTMLButtonElement>('button[type="reset"]'),
   };
 }

--- a/custom-elements/auto-complete-element/src/auto-complete.ts
+++ b/custom-elements/auto-complete-element/src/auto-complete.ts
@@ -48,6 +48,11 @@ export default class AutoComplete {
       this.clearButton.setAttribute('aria-label', 'Clear autocomplete');
     }
 
+    // Disable auto-complete if the `disabled` attribute is present initially.
+    if (this.container.disabled) {
+      this.disable();
+    }
+
     this.onMousedown = this.onMousedown.bind(this);
     this.onInputBlur = this.onInputBlur.bind(this);
     this.onInputMousedown = this.onInputMousedown.bind(this);
@@ -173,6 +178,31 @@ export default class AutoComplete {
     this.selectionVariant.disconnect();
     this.list.hidden = true;
     dispatchEvent(this.container, 'hidden');
+  }
+
+  /**
+   * @description Enables the input field and the clear button so that it can respond to focus and user input.
+   */
+  enable() {
+    this.input.disabled = false;
+
+    if (this.clearButton) {
+      this.clearButton.disabled = false;
+      this.clearButton.removeAttribute('tabindex');
+    }
+  }
+
+
+  /**
+   * @description Disables the input field and the clear button. While disabled, it cannot receive focus.
+   */
+  disable() {
+    this.input.disabled = true;
+
+    if (this.clearButton) {
+      this.clearButton.disabled = true;
+      this.clearButton.setAttribute('tabindex', '-1');
+    }
   }
 
   /**

--- a/custom-elements/auto-complete-element/src/auto-complete.ts
+++ b/custom-elements/auto-complete-element/src/auto-complete.ts
@@ -192,7 +192,6 @@ export default class AutoComplete {
     }
   }
 
-
   /**
    * @description Disables the input field and the clear button. While disabled, it cannot receive focus.
    */

--- a/custom-elements/auto-complete-element/src/element.ts
+++ b/custom-elements/auto-complete-element/src/element.ts
@@ -27,7 +27,7 @@ export default class AutoCompleteElement extends HTMLElement {
   }
 
   static get observedAttributes(): string[] {
-    return ['open'];
+    return ['open', 'disabled'];
   }
 
   attributeChangedCallback(name: string, oldValue: string, newValue: string) {
@@ -37,6 +37,9 @@ export default class AutoCompleteElement extends HTMLElement {
     switch (name) {
       case 'open':
         newValue === null ? this.autocomplete.hideList() : this.autocomplete.showList();
+        break;
+      case 'disabled':
+        newValue === null ? this.autocomplete.enable() : this.autocomplete.disable();
         break;
     }
   }
@@ -106,6 +109,12 @@ export default class AutoCompleteElement extends HTMLElement {
    * @description Shows/hides the list
    */
   set open(value: boolean) {
+    // Make sure that list is always hidden.
+    if (this.disabled) {
+      this.removeAttribute('open');
+      return;
+    }
+
     if (value) {
       this.setAttribute('open', '');
     } else {
@@ -128,6 +137,24 @@ export default class AutoCompleteElement extends HTMLElement {
       this.setAttribute('multiple', '');
     } else {
       this.removeAttribute('multiple');
+    }
+  }
+
+  /**
+   * @description Whether the `auto-complete` is disabled or not.
+   */
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
+
+  /**
+   * @description Enables/disables the `auto-complete` element.
+   */
+  set disabled(value: boolean) {
+    if (value) {
+      this.setAttribute('disabled', '');
+    } else {
+      this.removeAttribute('disabled');
     }
   }
 


### PR DESCRIPTION
Support the `disabled` attribute. If present,
- disables the input field
- disables the clear button if it exists

The main idea here is to avoid user interactions. Functions such as `setValue` and `removeValue` will still work as expected.
