### PR TITLE
fix: list initially open

### DIFF
--- a/custom-elements/auto-complete-element/CHANGELOG.md
+++ b/custom-elements/auto-complete-element/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The main idea here is to avoid user interactions. Functions such as `setValue` and `removeValue` will still work as
   expected.
 
+### Fixed
+
+- List should have the `hidden` attribute and the `auto-complete` element should not have the `open` attribute initially.
+
 ## [2.0.1] - 2023-03-02
 
 ### Added

--- a/custom-elements/auto-complete-element/spec/utils.ts
+++ b/custom-elements/auto-complete-element/spec/utils.ts
@@ -62,7 +62,7 @@ export async function setupFixture({
       >
       <input type="text" />
       ${clearable && html`<button type="button" data-clear>X</button>`}
-      <ul id="list" hidden>
+      <ul id="list">
         ${options.map(
           (option) =>
             html`<li

--- a/custom-elements/auto-complete-element/src/auto-complete.ts
+++ b/custom-elements/auto-complete-element/src/auto-complete.ts
@@ -31,6 +31,10 @@ export default class AutoComplete {
     this.input = input;
     this.list = list;
 
+    // List shouldn't be opened initially because it's a form control.
+    this.list.hidden = true;
+    this.container.open = false;
+
     this.combobox = new Combobox(this.input, this.list, { multiple: this.container.multiple });
     this.selectionVariant = this.container.multiple
       ? new MultiSelection(this.container, this, this.input)


### PR DESCRIPTION
Since it's a form control, the list should have the `hidden` attribute and the `auto-complete` element should not have the `open` attribute initially.

fixes #51 